### PR TITLE
Introduced Jabbr version parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,13 +6,21 @@ A nodejs [Jabbr](https://github.com/davidfowl/JabbR) client
 
     npm install njabbr
 
+## Configuration
+
+    The Jabbr version must be specified either through the jabbrVersion setting
+    on JabbrClient options or the environment variable JABBR_VERSION
+    If the version is not set, the client will be spammed with outOfSync
+    messages from Jabbr.
+
+
 ## Usage
 
 ```javascript
 var JabbrClient = require('njabbr').JabbrClient;
 var JabbrClientEvents = require('njabbr').JabbrClientEvents;
 
-var client = new JabbrClient("http://jabbr.url/");
+var client = new JabbrClient("http://jabbr.url/", {jabbrVersion: "1.0.5420.15349"});
 
 client.on(JabbrClientEvents.onMessageReceived, function(msg, room) {
 });

--- a/lib/hubs.js
+++ b/lib/hubs.js
@@ -104,6 +104,7 @@ var SignalR = require('./signalr.core').SignalR,
       useDefaultPath: true
     },
     connection = this;
+    connection.jabbrVersion = options.jabbrVersion;
 
     $.extend(settings, options);
 

--- a/lib/jabbrclient.js
+++ b/lib/jabbrclient.js
@@ -57,11 +57,14 @@ var util = require('util'),
   exports.JabbrClient = function(url, options) {
     var self = this
       , options = options || {}
-      , transport = options.transport || "serverSentEvents";
+      , transport = options.transport || "serverSentEvents"
+      , jabbrVersion = options.jabbrVersion || process.env.JABBR_VERSION || "'versionNotSet'";
+
     this.url = url;
-    this.hub = new HubConnection(url);
+    this.hub = new HubConnection(url, {jabbrVersion: jabbrVersion});
     this.clientTransport = SignalRTransports[transport];
     this.log("Configured to use " + this.clientTransport.name + " transport");
+    this.log("Configured to use Jabbr version " + jabbrVersion);
     this.hub.createHubProxies();
     this.hub.proxies.chat.client = {
       addMessage: function(message, room) {
@@ -91,9 +94,10 @@ var util = require('util'),
   exports.JabbrClient.prototype.connect = function(username, password, onSuccess) {
     var self = this,
         options = {
-          transport: self.clientTransport
+          transport: self.clientTransport,
+          jabbrVersion: self.jabbrVersion
         };
-    
+
     // before we start the hub we need to authenticate...
     this.authenticate(username, password)
       .fail(function(e) {

--- a/lib/jabbrclient.js
+++ b/lib/jabbrclient.js
@@ -48,7 +48,7 @@ var util = require('util'),
   };
 
   exports.JabbrClientEvents = JabbrClientEvents;
-  
+
   /**
    *
    * @param url The url of the jabbr server
@@ -58,7 +58,7 @@ var util = require('util'),
     var self = this
       , options = options || {}
       , transport = options.transport || "serverSentEvents"
-      , jabbrVersion = options.jabbrVersion || process.env.JABBR_VERSION || "'versionNotSet'";
+      , jabbrVersion = options.jabbrVersion || process.env.JABBR_VERSION || "";
 
     this.url = url;
     this.hub = new HubConnection(url, {jabbrVersion: jabbrVersion});

--- a/lib/transports/common.js
+++ b/lib/transports/common.js
@@ -174,7 +174,9 @@
       // the jabbr version only seems to be output to the client here:
       //  https://github.com/JabbR/JabbR/blob/3bdc5d3228443affbdc38635e2c8e455f1f1fde7/JabbR/Views/Home/index.cshtml#L564
       // need to find another way to grab the jabbr version
-      qs += "&version=" + connection.jabbrVersion;
+      if (connection.jabbrVersion != "") {
+        qs += "&version=" + connection.jabbrVersion;
+      }
 
       if (connection.data) {
         qs += "&connectionData=" + encodeURIComponent(connection.data);

--- a/lib/transports/common.js
+++ b/lib/transports/common.js
@@ -170,6 +170,12 @@
           url = baseUrl + connection.appRelativeUrl,
           qs = "transport=" + transport + "&connectionToken=" + encodeURIComponent(connection.token);
 
+      // HACK: add jabbr version so we're not spammed with outOfSync messages
+      // the jabbr version only seems to be output to the client here:
+      //  https://github.com/JabbR/JabbR/blob/3bdc5d3228443affbdc38635e2c8e455f1f1fde7/JabbR/Views/Home/index.cshtml#L564
+      // need to find another way to grab the jabbr version
+      qs += "&version=" + connection.jabbrVersion;
+
       if (connection.data) {
         qs += "&connectionData=" + encodeURIComponent(connection.data);
       }

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
         }
     ],
     "dependencies": {
-        "request": "latest",
+        "request": "2.27.0",
         "eventsource": "latest",
         "Deferred": "0.1.1",
         "moment": "latest"


### PR DESCRIPTION
Newer versions of Jabbr require the client to specify which version of Jabbr is being used, otherwise the client is spammed with outOfSync messages.

It seems the Jabbr version is only output to the client on a specific view: https://github.com/JabbR/JabbR/blob/3bdc5d3228443affbdc38635e2c8e455f1f1fde7/JabbR/Views/Home/index.cshtml#L564

Now when the JabbrClient is instantiated, the jabbrVersion can be specified. Or you can set the version through an environment variable: JABBR_VERSION

The environment variable is important the hubot-jabbr package uses njabbr. This will allow the user to continue to update the jabbr version without requiring updates to hubot-jabbr.

I also forced the request module to be at version 2.27.0, at least for now. It seems your working on using the new cookie stuff from request. This at least gets things working until that conversion is complete.